### PR TITLE
fix: help command

### DIFF
--- a/src/main/kotlin/dev/shiron/kotodiscord/command/HelpService.kt
+++ b/src/main/kotlin/dev/shiron/kotodiscord/command/HelpService.kt
@@ -84,6 +84,6 @@ class HelpService
 
         private fun getHelp(command: String): String {
             val cmdStr = command.replace(" ", ".")
-            return i18n.format("command.help.$cmdStr")
+            return i18n.format("command.description.$cmdStr")
         }
     }


### PR DESCRIPTION
This pull request includes a small change to the `HelpService` class in `HelpService.kt`. The change updates the localization key used in the `getHelp` method to retrieve command descriptions instead of help text.